### PR TITLE
client shouldn't use echo on exception

### DIFF
--- a/src/RecommApi/Client.php
+++ b/src/RecommApi/Client.php
@@ -81,7 +81,6 @@ class Client{
         catch(\Requests_Exception $e)
         {
             if(strpos($e->getMessage(), 'cURL error 28') !== false) throw new ApiTimeoutException($request);
-            echo "{$e->getMessage()}";
             throw $e;
         }
 


### PR DESCRIPTION
on curl exception other than 'cURL error 28' client used to echo message
directly to stdout which if used in a web application goes to http response
 and therefore causes trouble