### PR TITLE
Composer.json improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or
 ```
 {
     "require": {
-        "recombee/php-api-client": ">=1.3"
+        "recombee/php-api-client": "^1.3"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Recombee\\": "src/",
+            "Recombee\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Recombee\\RecommApi\\Tests\\": "tests/"
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
       "php": ">=5.4.0",
-      "rmccue/requests": ">=1.7"
+      "rmccue/requests": "^1.7.1"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4",


### PR DESCRIPTION
Define dependencies with upper bound, to avoid installing any (even backward incompatible) future version - only compatible version (as per SemVer) should be installed. See also https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md 

Also usage of `autoload-dev` is described here: https://getcomposer.org/doc/04-schema.md#autoload-dev