### PR TITLE
Fix post response when de json decode result is an empty array

### DIFF
--- a/src/RecommApi/Client.php
+++ b/src/RecommApi/Client.php
@@ -155,7 +155,8 @@ class Client{
         $this->checkErrors($response);
 
         $json = json_decode($response->body, true);
-        if($json)
+
+        if($json !== null && json_last_error() == JSON_ERROR_NONE)
             return $json;
         else
             return $response->body;


### PR DESCRIPTION
This PR fixes the following problem : 

The condition `if ($json)` results to false when the response of the `json_decode($response->body, true);` is an empty array.
The post method will then return the `$response->body` instead of empty array. 