### PR TITLE
Missing use statement

### DIFF
--- a/src/RecommApi/Requests/SetValues.php
+++ b/src/RecommApi/Requests/SetValues.php
@@ -5,6 +5,7 @@
  * @author Ondrej Fiedler <ondrej.fiedler@recombee.com>
  */
 namespace Recombee\RecommApi\Requests;
+use Recombee\RecommApi\Exceptions\UnknownOptionalParameterException;
 
 /**
  * Set/update (some) property values of an entity.


### PR DESCRIPTION
Hi
When using a bad optional parameters, exception is not thrown due to missing use statement.
Regards;