### PR TITLE
Utilize SensitiveParameter attribute

### DIFF
--- a/src/RecommApi/Client.php
+++ b/src/RecommApi/Client.php
@@ -10,6 +10,7 @@ use Recombee\RecommApi\Requests\Request;
 use Recombee\RecommApi\Exceptions\ResponseException;
 use Recombee\RecommApi\Exceptions\ApiTimeoutException;
 use Recombee\RecommApi\Util\Util;
+use SensitiveParameter;
 
 /**
  * Client for easy usage of Recombee recommendation API
@@ -36,7 +37,12 @@ class Client{
      * @param string $token Secret token
      * @param array  $options Other custom options
      */
-    public function __construct($account, $token, $options = array()) {
+    public function __construct(
+        $account,
+        #[SensitiveParameter]
+        $token,
+        $options = array()
+    ) {
         $this->account = $account;
         $this->token = $token;
 
@@ -240,7 +246,11 @@ class Client{
         return $res;
     }
 
-    protected function hmacSign($uri, $timeStr) {
+    protected function hmacSign(
+        $uri,
+        #[SensitiveParameter]
+        $timeStr
+    ) {
         $url = $uri . $timeStr;
         return hash_hmac('sha1', $url, $this->token);
     }

--- a/src/RecommApi/Client.php
+++ b/src/RecommApi/Client.php
@@ -246,11 +246,7 @@ class Client{
         return $res;
     }
 
-    protected function hmacSign(
-        $uri,
-        #[SensitiveParameter]
-        $timeStr
-    ) {
+    protected function hmacSign($uri, $timeStr) {
         $url = $uri . $timeStr;
         return hash_hmac('sha1', $url, $this->token);
     }


### PR DESCRIPTION
This PR adds the php native `SensitiveParameter` to parameters which are secruity relevant.
When the code is running on PHP8.2+ this will lead to masking of the contents, so we don't leak secrets into logfiles or with debug out.

I am putting the `#[SensitiveParameter]` onto a separate line, to make sure the code stays PHP 7.x compatible.
In case we would put the attribute onto the same line as the parameters, we would loose PHP7.x compatibility.
As is, PHP7.x will treat this line as a full-line comment and just ignore it.

see https://php.watch/versions/8.2/backtrace-parameter-redaction#SensitiveParameter